### PR TITLE
Tiga 878/filter experiment table

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -17,3 +17,9 @@
 __pycache__/
 # Ignored by the build system
 /setup.cfg
+
+# folders that should not be uploaded to app engine
+local_results/
+local_experiment_results/
+test/
+.venv/

--- a/pixaris/experiment_handlers/gcp.py
+++ b/pixaris/experiment_handlers/gcp.py
@@ -376,7 +376,7 @@ class GCPExperimentHandler(ExperimentHandler):
         project: str,
         dataset: str,
         experiment_run_name: str,
-        results_directory: str,
+        local_results_directory: str,
     ) -> list[str]:
         """
         Downloads images for a experiment_run_name from GCP bucket to local directory.
@@ -388,8 +388,8 @@ class GCPExperimentHandler(ExperimentHandler):
         :type dataset: str
         :param experiment_run_name: Name of the experiment run.
         :type experiment_run_name: str
-        :param results_directory: The local directory to store the downloaded images.
-        :type results_directory: str
+        :param local_results_directory: The local directory to store the downloaded images.
+        :type local_results_directory: str
         :return: List of local image paths.
         :rtype: list[str]
         """
@@ -411,7 +411,7 @@ class GCPExperimentHandler(ExperimentHandler):
             if blob.name.endswith("/"):
                 continue  # directory, skip.
             image_path_local = os.path.join(
-                results_directory, blob.name.replace("results/", "")
+                local_results_directory, blob.name.replace("results/", "")
             )
             local_image_paths.append(image_path_local)
 

--- a/pixaris/experiment_handlers/local.py
+++ b/pixaris/experiment_handlers/local.py
@@ -194,8 +194,10 @@ class LocalExperimentHandler(ExperimentHandler):
             experiment_run_name,
             "generated_images",
         )
-        return [
+        local_image_paths = [
             os.path.join(results_dir, image_name)
             for image_name in os.listdir(results_dir)
             if image_name.endswith((".png", ".jpg", ".jpeg"))
         ]
+        local_image_paths.sort()
+        return local_image_paths

--- a/pixaris/frontend/tab_feedback.py
+++ b/pixaris/frontend/tab_feedback.py
@@ -55,11 +55,11 @@ def render_feedback_tab(
                 filterable=True,
             )
 
-            # initialise hidden feedback iterations and button
+            # initialise hidden feedback iterations and define updating function
             feedback_iterations = gr.Dropdown(visible=False)
 
             def update_feedback_iteration_choices(project_name, feedback_iterations):
-                """Update choices of feedback iterations for selected project and display reload button."""
+                """Update choices of feedback iterations for selected project."""
                 feedback_handler.load_all_feedback_iterations_for_project(project_name)
                 feedback_iteration_choices = feedback_handler.feedback_iteration_choices
 
@@ -74,6 +74,7 @@ def render_feedback_tab(
                 )
                 return feedback_iterations
 
+            # update feedback iterations choices upon project change
             project_name.change(
                 fn=update_feedback_iteration_choices,
                 inputs=[


### PR DESCRIPTION
This pull request introduces several changes across multiple files to improve code clarity, functionality, and maintainability. The most significant updates include adjustments to variable naming for better clarity, enhancements to UI components in the frontend, and updates to `.gcloudignore` to exclude unnecessary directories from deployment.

### Frontend Enhancements:
* Improved the experiment tracking tab in `pixaris/frontend/tab_experiment_tracking.py` by adding comments, initializing hidden UI elements, and defining update functions for datasets and experiments. This includes renaming and restructuring functions for better readability and functionality.
* Updated the gallery height slider's default value from 360 to 200 for better UI adaptability.
* Refactored the table rendering logic to filter and display experiment results based on selected experiments, improving the user experience.

### Code Clarity and Consistency:
* Renamed the `results_directory` parameter to `local_results_directory` in `pixaris/experiment_handlers/gcp.py` for better clarity and updated all references, including docstrings and code logic. 

### Backend Improvements:
* Added sorting of image paths before returning them in `pixaris/experiment_handlers/local.py` to ensure consistent ordering.

### Deployment Configuration:
* Updated `.gcloudignore` to exclude additional local directories (`local_results/`, `local_experiment_results/`, `test/`, `.venv/`) from deployment to prevent unnecessary files from being uploaded to App Engine.