### PR TITLE
Refactor dataset loaders

### DIFF
--- a/pixaris/data_loaders/base.py
+++ b/pixaris/data_loaders/base.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
-from typing import Iterable
+from typing import Iterable, List
+import os
+from PIL import Image
 
 
 class DatasetLoader:
@@ -8,3 +10,43 @@ class DatasetLoader:
     @abstractmethod
     def load_dataset(self) -> Iterable[dict[str, any]]:
         pass
+
+    def _retrieve_and_check_dataset_image_names(
+        self, dataset_dir: str, image_dirs: List[str]
+    ) -> List[str]:
+        """Return all image names and verify directory contents match."""
+
+        basis_names = os.listdir(os.path.join(dataset_dir, image_dirs[0]))
+        basis_names = [name for name in basis_names if name != ".DS_Store"]
+        for image_dir in image_dirs:
+            image_names = os.listdir(os.path.join(dataset_dir, image_dir))
+            image_names = [name for name in image_names if name != ".DS_Store"]
+            if basis_names != image_names:
+                raise ValueError(
+                    "The names of the images in each image directory should be the same."
+                    f" {image_dirs[0]} does not match {image_dir}."
+                )
+        return basis_names
+
+    def _assemble_dataset(
+        self,
+        dataset_dir: str,
+        image_dirs: List[str],
+        image_names: List[str],
+    ) -> List[dict[str, List[dict[str, Image.Image]]]]:
+        """Build dataset dictionary from local paths."""
+
+        dataset = []
+        for image_name in image_names:
+            pillow_images = []
+            for image_dir in image_dirs:
+                image_path = os.path.join(dataset_dir, image_dir, image_name)
+                pillow_image = Image.open(image_path)
+                pillow_images.append(
+                    {
+                        "node_name": f"Load {image_dir.capitalize()} Image",
+                        "pillow_image": pillow_image,
+                    }
+                )
+            dataset.append({"pillow_images": pillow_images})
+        return dataset

--- a/pixaris/data_loaders/gcp.py
+++ b/pixaris/data_loaders/gcp.py
@@ -138,34 +138,6 @@ class GCPDatasetLoader(DatasetLoader):
                     )
                 )
 
-    def _retrieve_and_check_dataset_image_names(self):
-        """
-        Retrieves the names of the images in the evaluation set and checks if they are the same in each image directory.
-
-        :return: The names of the images in the evaluation set.
-        :rtype: List[str]
-        :raises: ValueError: If the names of the images in each image directory are not the same.
-        """
-        basis_names = os.listdir(
-            os.path.join(
-                self.eval_dir_local, self.project, self.dataset, self.image_dirs[0]
-            )
-        )
-        basis_names = [name for name in basis_names if name != ".DS_Store"]
-        for image_dir in self.image_dirs:
-            image_names = os.listdir(
-                os.path.join(self.eval_dir_local, self.project, self.dataset, image_dir)
-            )
-            image_names = [name for name in image_names if name != ".DS_Store"]
-
-            if basis_names != image_names:
-                raise ValueError(
-                    "The names of the images in each image directory should be the same. {} does not match {}.".format(
-                        self.image_dirs[0], image_dir
-                    )
-                )
-        return basis_names
-
     def load_dataset(
         self,
     ) -> List[dict[str, List[dict[str, Image.Image]]]]:
@@ -179,26 +151,8 @@ class GCPDatasetLoader(DatasetLoader):
         :rtype: List[dict[str, List[dict[str, Image.Image]]]]:
         """
         self._download_dataset()
-        image_names = self._retrieve_and_check_dataset_image_names()
-
-        dataset = []
-        for image_name in image_names:
-            pillow_images = []
-            for image_dir in self.image_dirs:
-                image_path = os.path.join(
-                    self.eval_dir_local,
-                    self.project,
-                    self.dataset,
-                    image_dir,
-                    image_name,
-                )
-                # Load the image using PIL
-                pillow_image = Image.open(image_path)
-                pillow_images.append(
-                    {
-                        "node_name": f"Load {image_dir.capitalize()} Image",
-                        "pillow_image": pillow_image,
-                    }
-                )
-            dataset.append({"pillow_images": pillow_images})
-        return dataset
+        dataset_dir = os.path.join(self.eval_dir_local, self.project, self.dataset)
+        image_names = self._retrieve_and_check_dataset_image_names(
+            dataset_dir, self.image_dirs
+        )
+        return self._assemble_dataset(dataset_dir, self.image_dirs, image_names)

--- a/pixaris/data_loaders/local.py
+++ b/pixaris/data_loaders/local.py
@@ -47,66 +47,12 @@ class LocalDatasetLoader(DatasetLoader):
                 f"Please ensure the dataset contains subdirectories with images."
             )
 
-    def _retrieve_and_check_dataset_image_names(self):
-        """
-        Retrieves the names of the images in the evaluation set and checks if they are the same in each image directory.
-
-        :raises ValueError: If the names of the images in each image directory are not the same.
-        :return: The names of the images in the evaluation set.
-        :rtype: list[str]
-        """
-        basis_names = os.listdir(
-            os.path.join(
-                self.eval_dir_local, self.project, self.dataset, self.image_dirs[0]
-            )
-        )
-        basis_names = [name for name in basis_names if name != ".DS_Store"]
-        for image_dir in self.image_dirs:
-            image_names = os.listdir(
-                os.path.join(self.eval_dir_local, self.project, self.dataset, image_dir)
-            )
-            image_names = [name for name in image_names if name != ".DS_Store"]
-
-            if basis_names != image_names:
-                raise ValueError(
-                    "The names of the images in each image directory should be the same. {} does not match {}.".format(
-                        self.image_dirs[0], image_dir
-                    )
-                )
-        return basis_names
-
     def load_dataset(
         self,
     ) -> List[dict[str, List[dict[str, Image.Image]]]]:
-        """
-        Returns all images in the evaluation set as an iterable of dictionaries containing PIL Images.
-
-        :return: list of dicts containing data loaded from the local directory.
-            The key will always be "pillow_images".
-            The value is a dict mapping node names to PIL Image objects.
-            This dict has a key for each directory in the image_dirs list representing a Node Name.
-        :rtype: List[dict[str, List[dict[str, Image.Image]]]]:
-        """
-        image_names = self._retrieve_and_check_dataset_image_names()
-
-        dataset = []
-        for image_name in image_names:
-            pillow_images = []
-            for image_dir in self.image_dirs:
-                image_path = os.path.join(
-                    self.eval_dir_local,
-                    self.project,
-                    self.dataset,
-                    image_dir,
-                    image_name,
-                )
-                # Load the image using PIL
-                pillow_image = Image.open(image_path)
-                pillow_images.append(
-                    {
-                        "node_name": f"Load {image_dir.capitalize()} Image",
-                        "pillow_image": pillow_image,
-                    }
-                )
-            dataset.append({"pillow_images": pillow_images})
-        return dataset
+        """Return all images for this dataset."""
+        dataset_dir = os.path.join(self.eval_dir_local, self.project, self.dataset)
+        image_names = self._retrieve_and_check_dataset_image_names(
+            dataset_dir, self.image_dirs
+        )
+        return self._assemble_dataset(dataset_dir, self.image_dirs, image_names)

--- a/test/data_loaders/test_gcp_data_loader.py
+++ b/test/data_loaders/test_gcp_data_loader.py
@@ -121,7 +121,10 @@ class TestLocalDataset(unittest.TestCase):
             eval_dir_local="temp_test_files",
         )
         loader.image_dirs = ["input", "mask"]
-        image_names = loader._retrieve_and_check_dataset_image_names()
+        dataset_dir = os.path.join("temp_test_files", "test_project", "mock")
+        image_names = loader._retrieve_and_check_dataset_image_names(
+            dataset_dir, loader.image_dirs
+        )
         self.assertEqual(
             set(image_names),
             set(["doggo.png", "cat.png", "sillygoose.png", "chinchilla.png"]),
@@ -146,11 +149,14 @@ class TestLocalDataset(unittest.TestCase):
             eval_dir_local="temp_test_files",
         )
         loader.image_dirs = ["input", "mask"]
+        dataset_dir = os.path.join("temp_test_files", "test_project", "faulty_names")
         with self.assertRaisesRegex(
             ValueError,
             "The names of the images in each image directory should be the same. input does not match mask.",
         ):
-            loader._retrieve_and_check_dataset_image_names()
+            loader._retrieve_and_check_dataset_image_names(
+                dataset_dir, loader.image_dirs
+            )
 
         # Clean up the temporary directory
         tearDown()

--- a/test/data_loaders/test_local_data_loader.py
+++ b/test/data_loaders/test_local_data_loader.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from pixaris.data_loaders.local import LocalDatasetLoader
 
@@ -23,7 +24,10 @@ class TestLocalDataset(unittest.TestCase):
             project="test_project", dataset="mock", eval_dir_local="test"
         )
         loader.image_dirs = ["input", "mask"]
-        image_names = loader._retrieve_and_check_dataset_image_names()
+        dataset_dir = os.path.join("test", "test_project", "mock")
+        image_names = loader._retrieve_and_check_dataset_image_names(
+            dataset_dir, loader.image_dirs
+        )
         self.assertEqual(
             set(image_names),
             set(["doggo.png", "cat.png", "sillygoose.png", "chinchilla.png"]),
@@ -34,11 +38,14 @@ class TestLocalDataset(unittest.TestCase):
             project="test_project", dataset="faulty_names", eval_dir_local="test"
         )
         loader.image_dirs = ["input", "mask"]
+        dataset_dir = os.path.join("test", "test_project", "faulty_names")
         with self.assertRaisesRegex(
             ValueError,
             "The names of the images in each image directory should be the same. input does not match mask.",
         ):
-            loader._retrieve_and_check_dataset_image_names()
+            loader._retrieve_and_check_dataset_image_names(
+                dataset_dir, loader.image_dirs
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove duplicated logic from dataset loaders
- add shared helpers to `DatasetLoader`
- adjust tests for new helpers

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684adc49c37c83249903ca8c9ab7eded