### PR TITLE
Fix feedback handler docstring parameter names

### DIFF
--- a/pixaris/feedback_handlers/base.py
+++ b/pixaris/feedback_handlers/base.py
@@ -99,8 +99,8 @@ class FeedbackHandler:
         Creates a feedback iteration, which involves persisting the creation to a feedback table as well as
         save the corresponding images.
 
-        :param images_directory: Path to local directory containing images to upload
-        :type images_directory: str
+        :param local_image_directory: Path to local directory containing images to upload
+        :type local_image_directory: str
         :param project: Name of the project
         :type project: str
         :param feedback_iteration: Name of the feedback iteration

--- a/pixaris/feedback_handlers/gcp.py
+++ b/pixaris/feedback_handlers/gcp.py
@@ -141,8 +141,8 @@ class GCPFeedbackHandler(FeedbackHandler):
         :type feedback_iteration: str
         :param image_names: List of image names to upload
         :type image_names: list[str]
-        :param images_directory: Path to local directory containing images to upload
-        :type images_directory: str
+        :param local_image_directory: Path to local directory containing images to upload
+        :type local_image_directory: str
         """
         storage_client = storage.Client(project=self.gcp_project_id)
         bucket = storage_client.bucket(self.gcp_pixaris_bucket_name)
@@ -166,8 +166,8 @@ class GCPFeedbackHandler(FeedbackHandler):
         """
         Upload images to GCP bucket and persist initialisation of feedback iteration to BigQuery.
 
-        :param images_directory: Path to local directory containing images to upload
-        :type images_directory: str
+        :param local_image_directory: Path to local directory containing images to upload
+        :type local_image_directory: str
         :param project: Name of the project
         :type project: str
         :param feedback_iteration: Name of the feedback iteration


### PR DESCRIPTION
## Summary
- use `local_image_directory` parameter consistently in feedback handler docstrings

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684adc569ce48324ba844c569fa5c483