### PR TITLE
Add tests for retry and BigQuery utils

### DIFF
--- a/test/metrics/test_metric_utils.py
+++ b/test/metrics/test_metric_utils.py
@@ -18,6 +18,26 @@ class TestHelpers(unittest.TestCase):
         dicts = [{"a": 1, "b": 2}, {"a": 2, "c": 3}]
         self.assertRaises(ValueError, dict_mean, dicts)
 
+    def test_normalize_image_sizes_and_background(self):
+        from PIL import Image
+        from pixaris.metrics.utils import normalize_image
+
+        img = Image.new("RGB", (200, 100), "red")
+        result = normalize_image(img, max_size=(300, 300))
+
+        self.assertEqual(result.size, (300, 300))
+        self.assertEqual(result.getpixel((0, 0)), (255, 255, 255))
+        center = (150, 150)
+        self.assertEqual(result.getpixel(center), (255, 0, 0))
+
+    def test_normalize_image_downscale(self):
+        from PIL import Image
+        from pixaris.metrics.utils import normalize_image
+
+        img = Image.new("RGB", (600, 400), "blue")
+        result = normalize_image(img, max_size=(300, 300))
+        self.assertEqual(result.size, (300, 300))
+
     def test_dict_mean_different_lengths(self):
         dicts = [{"a": 1, "b": 2}, {"a": 2, "b": 2, "c": 3}]
         self.assertRaises(ValueError, dict_mean, dicts)

--- a/test/utils/test_bigquery_utils.py
+++ b/test/utils/test_bigquery_utils.py
@@ -1,0 +1,88 @@
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+
+# Create fake google.cloud.bigquery module for import
+fake_bigquery = types.ModuleType("google.cloud.bigquery")
+
+
+class FakeSchemaField(SimpleNamespace):
+    pass
+
+
+class FakeTable:
+    def __init__(self, table_ref, schema=None):
+        self.table_ref = table_ref
+        self.schema = schema
+
+
+class FakeBigQueryClient:
+    def __init__(self):
+        self.created_tables = {}
+        self.existing_tables = {}
+
+    def get_table(self, table_ref):
+        if table_ref in self.existing_tables:
+            return self.existing_tables[table_ref]
+        raise Exception("Not found: Table")
+
+    def create_table(self, table):
+        self.created_tables[table.table_ref] = table
+        self.existing_tables[table.table_ref] = table
+
+
+# populate fake_bigquery namespace
+fake_bigquery.SchemaField = FakeSchemaField
+fake_bigquery.Table = FakeTable
+fake_bigquery.Client = FakeBigQueryClient
+
+sys.modules.setdefault("google", types.ModuleType("google"))
+sys.modules.setdefault("google.cloud", types.ModuleType("google.cloud"))
+sys.modules["google.cloud.bigquery"] = fake_bigquery
+
+from pixaris.utils import bigquery as bq_utils  # noqa: E402
+
+
+class TestBigQueryUtils(unittest.TestCase):
+    def test_python_type_to_bq_type(self):
+        self.assertEqual(bq_utils.python_type_to_bq_type(str), "STRING")
+        self.assertEqual(bq_utils.python_type_to_bq_type(int), "INTEGER")
+        self.assertEqual(bq_utils.python_type_to_bq_type(float), "FLOAT")
+        self.assertEqual(bq_utils.python_type_to_bq_type(bool), "BOOLEAN")
+        self.assertEqual(bq_utils.python_type_to_bq_type(bytes), "BYTES")
+        # default case
+        self.assertEqual(bq_utils.python_type_to_bq_type(dict), "STRING")
+
+    def test_create_schema_from_dict(self):
+        data = {"a": "text", "b": 1}
+        schema = bq_utils.create_schema_from_dict(data)
+        self.assertEqual(len(schema), 2)
+        self.assertEqual(schema[0].name, "a")
+        self.assertEqual(schema[0].field_type, "STRING")
+        self.assertEqual(schema[1].field_type, "INTEGER")
+
+    def test_ensure_table_exists_creates(self):
+        client = FakeBigQueryClient()
+        bq_utils.ensure_table_exists(
+            "dataset.table",
+            {"a": 1},
+            client,
+        )
+        self.assertIn("dataset.table", client.created_tables)
+
+    def test_ensure_table_exists_exists(self):
+        client = FakeBigQueryClient()
+        existing = FakeTable("dataset.table")
+        client.existing_tables["dataset.table"] = existing
+        bq_utils.ensure_table_exists(
+            "dataset.table",
+            {"a": 1},
+            client,
+        )
+        # Should not create new table
+        self.assertEqual(client.created_tables, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/utils/test_retry.py
+++ b/test/utils/test_retry.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import patch
+from pixaris.utils import retry as retry_module
+
+retry_internal = getattr(retry_module, "__retry_internal")
+
+
+class TestRetryInternal(unittest.TestCase):
+    def test_retry_success_after_failures(self):
+        call_count = {"count": 0}
+
+        def func():
+            call_count["count"] += 1
+            if call_count["count"] < 3:
+                raise ValueError("fail")
+            return "success"
+
+        with patch("time.sleep") as mock_sleep:
+            result = retry_internal(
+                func,
+                exceptions=ValueError,
+                tries=3,
+                delay=1,
+                max_delay=5,
+                backoff=2,
+            )
+            self.assertEqual(result, "success")
+            self.assertEqual(mock_sleep.call_count, 2)
+            self.assertEqual(mock_sleep.call_args_list[0].args[0], 1)
+            self.assertEqual(mock_sleep.call_args_list[1].args[0], 2)
+
+    def test_retry_exhaust_raises(self):
+        def func():
+            raise RuntimeError("always")
+
+        with patch("time.sleep") as mock_sleep:
+            with self.assertRaises(RuntimeError):
+                retry_internal(func, exceptions=RuntimeError, tries=2, delay=0.1)
+            self.assertEqual(mock_sleep.call_count, 1)
+
+
+class TestRetryDecorator(unittest.TestCase):
+    def test_retry_decorator(self):
+        call = {"count": 0}
+
+        @retry_module.retry(exceptions=ValueError, tries=2, delay=0)
+        def decorated(x):
+            call["count"] += 1
+            if call["count"] == 1:
+                raise ValueError("first")
+            return x * 2
+
+        self.assertEqual(decorated(3), 6)
+        self.assertEqual(call["count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cover retry logic with unit tests
- cover BigQuery helpers with unit tests
- test image normalization behaviour

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684adc26b7708324bd2d393451f4fad1